### PR TITLE
Enable Integration tests in Docker

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,12 @@
+# Using Docker
+
+## Build Image
+docker build -t ehrserver .
+
+
+## Run Server on port 8090
+docker run -p "8090:8090" ehrserver 
+
+
+## Run Tests
+docker run ehrserver grails test-app -integration

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,6 @@ EXPOSE 8090
 RUN grails dependency-report
 RUN chmod +x /app/docker-entrypoint.sh
 # Define default command.
-ENTRYPOINT ["bash","-c" ,"/app/docker-entrypoint.sh"]
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
+CMD ["grails", "-Dserver.port=8090", "run-app"]
+

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,7 +1,17 @@
 #!/bin/bash
-set -eo pipefail
+set -e
+
+if [ "$1" = 'grails' ]; then
+        echo "Running grails"
+
+echo "Starting Mysql server"
 mysqld_safe &
 sleep 5
+echo "Create Mysql table"
 echo "CREATE DATABASE IF NOT EXISTS ehrserver" | mysql -uroot
-sleep 5
-grails -Dserver.port=8090 run-app
+echo "CREATE DATABASE IF NOT EXISTS ehrservertest" | mysql -uroot
+sleep 1
+
+fi
+
+exec "$@"


### PR DESCRIPTION
Docker run now receives commands to execute so we can use docker for integration testing