### PR TITLE
Added better support for docker for production or dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,7 @@ RUN /opt/grails-3.3.10/bin/grails war
 
 FROM tomcat:8-jdk8-openjdk
 COPY --from=build /app/build/libs/app-2.2.beta.war /usr/local/tomcat/webapps/ROOT.war
+WORKDIR /app
+COPY --from=build /app/grails-app/conf/application.yml /app/config.yml
 EXPOSE 8080
 CMD ["catalina.sh", "run"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,15 @@
-FROM java
-ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update
-RUN apt-get install -y mysql-server
-
-# install grails
-RUN curl -L https://github.com/grails/grails-core/releases/download/v2.5.6/grails-2.5.6.zip  -o /grails.zip
-RUN unzip /grails.zip -d /opt
-ADD . /app
-
+FROM openjdk:8-alpine AS build
+RUN apk update && apk add wget unzip git
+RUN wget https://github.com/grails/grails-core/releases/download/v3.3.10/grails-3.3.10.zip
+RUN unzip grails-3.3.10.zip -d /opt/
+ENV GRAILS_HOME=/opt/grails-3.3.10
+ENV PATH="${GRAILS_HOME}/bin:${PATH}"
 WORKDIR /app
+# COPY . .
+RUN git clone https://github.com/ppazos/cabolabs-ehrserver.git .
+RUN /opt/grails-3.3.10/bin/grails war
 
-ENV GRAILS_HOME /opt/grails-2.5.6
-ENV PATH $GRAILS_HOME/bin:$PATH
-
-EXPOSE 8090
-RUN grails dependency-report
-RUN chmod +x /app/docker-entrypoint.sh
-# Define default command.
-ENTRYPOINT ["/app/docker-entrypoint.sh"]
-CMD ["grails", "-Dserver.port=8090", "run-app"]
-
+FROM tomcat:8-jdk8-openjdk
+COPY --from=build /app/build/libs/app-2.2.beta.war /usr/local/tomcat/webapps/ROOT.war
+EXPOSE 8080
+CMD ["catalina.sh", "run"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+version: '3.0'
+services:
+  web:
+    build: .
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./terminology:/app/terminology
+      - ./grails-app/conf/:/usr/local/tomcat/webapps/config
+      - ./opts:/usr/local/tomcat/opts
+      - ./versions:/usr/local/tomcat/versions
+      - ./grails-app/conf/application.yml:/app/config.yml
+    depends_on:
+      - db
+    environment:
+      - SPRING_CONFIG_LOCATION=/app/config.yml
+      - EHRSERVER_MYSQL_DB_BEHAVIOUR=create-drop
+      - EHRSERVER_MYSQL_DB_HOST=db
+      - EHRSERVER_MYSQL_DB_PORT=3306
+      - EHRSERVER_MYSQL_DB_USERNAME=ehrserver2
+      - EHRSERVER_MYSQL_DB_PASSWORD=ehrserver2
+      - EHRSERVER_DB_NAME=ehrserver2
+      - EHRSERVER_ALLOW_WEB_USER_REGISTER=false
+      - EHRSERVER_REST_SECRET=d9507256-e461-4336-a6ec-2f412796f134
+      - EHRSERVER_EMAIL_HOST=localhost
+      - EHRSERVER_EMAIL_PORT=2525
+  db:
+    image: mysql:5.7
+    volumes:
+      - database:/var/lib/mysql
+    environment:
+      - MYSQL_DATABASE=ehrserver2
+      - MYSQL_USER=ehrserver2
+      - MYSQL_PASSWORD=ehrserver2
+      - MYSQL_ROOT_PASSWORD=root
+volumes:
+  database: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,8 @@ services:
       - ./grails-app/conf/:/usr/local/tomcat/webapps/config
       - ./opts:/usr/local/tomcat/opts
       - ./versions:/usr/local/tomcat/versions
-      - ./grails-app/conf/application.yml:/app/config.yml
+      # can be used to load a custom yml
+      # - ./grails-app/conf/application.yml:/app/config.yml
     depends_on:
       - db
     environment:

--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -217,8 +217,8 @@ dataSource:
     pooled: true
     jmxExport: true
     driverClassName: com.mysql.cj.jdbc.Driver
-    username: user
-    password: user1234
+    username: ${EHRSERVER_MYSQL_DB_USERNAME}
+    password: ${EHRSERVER_MYSQL_DB_PASSWORD}
 
 environments:
     development:
@@ -231,8 +231,8 @@ environments:
             url: jdbc:mysql://localhost:3306/ehrserver2_test?useTimezone=true&serverTimezone=UTC
     production:
         dataSource:
-            dbCreate: update
-            url: jdbc:mysql://localhost:3306/ehrserver2_prod?useTimezone=true&serverTimezone=UTC
+            dbCreate: ${EHRSERVER_MYSQL_DB_BEHAVIOUR}
+            url: jdbc:mysql://${EHRSERVER_MYSQL_DB_HOST}:${EHRSERVER_MYSQL_DB_PORT}/${EHRSERVER_DB_NAME}?useTimezone=true&serverTimezone=UTC
             properties:
                 jmxEnabled: true
                 initialSize: 5


### PR DESCRIPTION
Updated `Dockerfile` and added `docker-compose.yml` that allow user to have a n easy setup experience.
Minor changes in the docker-compose will be needed to make it work for prod environment like changing the `EHRSERVER_MYSQL_DB_BEHAVIOUR` to `update` or map a location of yml configuration.

`application.yml` also now respects environment variables for production/war environment.

Process followed by the `docker-compose` file:

1. Dockerfile first builds war using grails 3.3.10
2. Load the generated war to tomcat 8 with jdk8
3. Create a mysql 5.7 database image and load it with user (database data are in a persistent volume)
4. Start ehrsever

Regards