### PR TITLE
Add a workflow to publish a Docker image when a version is released

### DIFF
--- a/.github/workflows/publish-dockerhub.yaml
+++ b/.github/workflows/publish-dockerhub.yaml
@@ -1,0 +1,37 @@
+name: Publish the Docker image in DockerHub
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  build-push:
+    name: Build and push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      
+      - name: Prepare Tags
+        id: prepare-tags
+        run: |
+          echo ::set-output name=git-tag::${GITHUB_REF#refs/tags/}
+          echo ::set-output name=git-short-sha::${GITHUB_SHA::7}
+
+      - name: Build and Push
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: |
+            ${{ secrets.DOCKER_REPO }}:latest
+            ${{ secrets.DOCKER_REPO }}:${{ steps.prepare-tags.outputs.git-tag }}
+            ${{ secrets.DOCKER_REPO }}:${{ steps.prepare-tags.outputs.git-short-sha }}


### PR DESCRIPTION
This PR automates the release process. Now, when a GitHub release is published a GitHub Actions workflow will build the Docker image for this new version and publish it (`docker push`) in DockerHub.

In order to do this we need to add 3 secrets to this repository:
- `DOCKER_USERNAME`: DockerHub account username
- `DOCKER_PASSWORD`: DockerHub password
- `DOCKER_REPO`: Target repository (i.e. `cabolabs/ehrserver`)

Every image will be tagged with: `latest`, `git-tag` and `commit-short-sha`. Now the image version will be handled with tags instead of the image name (because this is a bad practice). Below some examples:
- cabolabs/ehrserver or cabolabs/ehrserver:**latest** (always point to the latest version)
- cabolabs/ehrserver:**v2.3** (image tag equals to github tag)
- cabolabs/ehrserver:**835cef5** (image tag is the github commit sha, in short format)